### PR TITLE
Update readme & manifest

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,22 @@ This custom Home Assistant integration is a work in progress that uses the newly
 * Aroma Diffuser - power switch
 * Socket - power switch
 
+## Installing
+You can install this integration with HACS or manually.
+### HACS
+After installing HACS ([click here for instructions](https://hacs.xyz/docs/setup/download/)), open the custom repositories section and paste the URL of this repo in. Then set the category to "integration". Then open the integrations page and add 'goveelife'.
+
+### Manually
+Copy the custom_components/goveelife to your custom_components folder. Reboot Home Assistant and configure the 'goveelife' integration via the integrations page.
+
+### Configuration
+When you add the goveelife integration, you will be prompted for an API key. To get this, you will need to:
+1. Open the 'Govee Home' app on your smartphone
+2. Login or create an account
+3. Open the settings and tap "Apply for an API key"
+4. Check your email to find the API key and use it when adding this integration to your Home Assistant instance.
+
+Note: the integration has the option of changing the polling frequence which is how often it will hit the Govee API to check for updates. If you set this value too low, you will be rate limited and you will not be able to control your devices.
 
 ## How can YOU help?
 I need API responses so I can continue to build out this integration. You can provide these resonses by opening an "issue" at the top of this repository. It's pretty simple. Use any online API query tool, and submit a GET requ

--- a/custom_components/goveelife/manifest.json
+++ b/custom_components/goveelife/manifest.json
@@ -1,11 +1,11 @@
 {
   "domain": "goveelife",
   "name": "Govee Life",
-  "version": "0.2.0",
+  "version": "3.1.0",
   "config_flow": true,
-  "documentation": "https://github.com/mk-maddin/goveelife-HA",
+  "documentation": "https://github.com/disforw/goveelife",
   "requirements": ["requests>=2.31.0"],
   "dependencies": ["diagnostics","sensor"],
-  "codeowners": ["@mk-maddin"],
+  "codeowners": ["@disforw"],
   "iot_class": "cloud_poll"
 }


### PR DESCRIPTION
Just a small update to add installation instructions to the readme as well as change the manifest to match the version in the Github release tab. Let me know if thats the correct version you want to use.

I would also suggest adding this repo as a HACS default as it will make the install easier for users. I think you would have to do that @disforw since you are the repo owner. Steps are here: https://hacs.xyz/docs/publish/include/ 