### PR TITLE
fix: update supported_features to use LightEntityFeature enum

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 This custom Home Assistant integration is a work in progress that uses the newly released API 2.0 by Govee. Feel free to contribute, all help is appreciated.
 
 ## Supported Devices 
-* Lights - Light entity, color selection, dimming
+* Lights - Light entity, color selection, dimming, effects
 * Heaters - Climate, power, oscillation
 * Air Purifiers - Fan entity, presets
 * Fans - Fan entity, presets

--- a/custom_components/goveelife/light.py
+++ b/custom_components/goveelife/light.py
@@ -183,13 +183,11 @@ class GoveeLifeLight(LightEntity, GoveeLifePlatformEntity, RestoreEntity):
         return RGBint
 
     @property
-    def supported_features(self) -> int:
+    def supported_features(self) -> LightEntityFeature:
         """Flag supported features."""
-        features = 0
-        if self._support_scenes and (self._available_scenes or self._dynamic_scenes):
-            features |= LightEntityFeature.EFFECT
-            _LOGGER.debug("%s - %s: Enabling EFFECT feature", self._api_id, self._identifier)
-        return features
+        if self._support_scenes or self._has_dynamic_scenes:
+            return LightEntityFeature.EFFECT
+        return LightEntityFeature(0) 
 
     @property
     def supported_color_modes(self) -> set[ColorMode] | set[str] | None:


### PR DESCRIPTION
**Issue:**
- Lights were triggering deprecation warning: "Entity light.xxx is using deprecated supported features values which will be removed in HA Core 2025.1"
- The `supported_features` property was returning raw integer values instead of `LightEntityFeature` enum
- Features were being reported as 0 initially because the method checked if scenes were loaded rather than if scene support was available

**Solution:**
- Changed return type from `int` to `LightEntityFeature` enum
- Removed runtime check for loaded scenes - now checks only if device supports scenes
- Ensures EFFECT feature is properly reported to HA before dynamic scenes are loaded

Also updated README.md with support for effects