### PR TITLE
Add dreamViewToggle support

### DIFF
--- a/custom_components/goveelife/switch.py
+++ b/custom_components/goveelife/switch.py
@@ -25,6 +25,7 @@ platform_device_types = [
     'devices.types.socket:.*on_off:.*',
     'devices.types.socket:.*toggle:.*',
     'devices.types.light:.*toggle:gradientToggle',
+    'devices.types.light:.*toggle:dreamViewToggle',
     'devices.types.ice_maker:.*on_off:.*',
     'devices.types.aroma_diffuser:.*on_off:.*',
     'devices.types.humidifier:.*on_off:.*',


### PR DESCRIPTION
Adds support for the `dreamViewToggle` capability found in H706C (Permanent Outdoor Lights Pro) devices.

**Changes:**
- switch.py: Added pattern for `dreamViewToggle` capability

This enables automatic creation of a switch entity for controlling Dream View mode on compatible devices.

Related: #104