### PR TITLE
Fix config flow 500 error in HA 2025.1+

### DIFF
--- a/custom_components/goveelife/config_flow.py
+++ b/custom_components/goveelife/config_flow.py
@@ -82,7 +82,6 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
     def __init__(self, config_entry: config_entries.ConfigEntry) -> None:
         """Initialize the options flow handler."""
         _LOGGER.debug("%s - OptionsFlowHandler: __init__: %s", DOMAIN, config_entry)
-        self.config_entry = config_entry
 
     async def async_step_init(self, user_input: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
         """Manage the options for Govee Life."""


### PR DESCRIPTION
Fixes the "Config flow could not be loaded: 500 Internal Server Error" when trying to configure the integration.

**Changes:**
- config_flow.py: Removed deprecated `self.config_entry = config_entry` assignment

**Root Cause:**
Home Assistant 2025.1+ changed `config_entry` to a read-only property on the `OptionsFlow` base class. Attempting to manually set it causes an `AttributeError`.

**Impact:**
- Fixes configuration UI (Settings > Configure button)
- Allows users to change scan interval and other settings
- Resolves 500 errors when opening integration options

Fixes #113