### PR TITLE
Move modes data into `_init_platform_specific` + switch to instance v…

### DIFF
--- a/custom_components/goveelife/fan.py
+++ b/custom_components/goveelife/fan.py
@@ -86,9 +86,6 @@ class GoveeLifeFan(FanEntity, GoveeLifePlatformEntity):
 
     _state_mapping = {}
     _state_mapping_set = {}
-    _attr_preset_modes = []
-    _attr_preset_modes_mapping = {}
-    _attr_preset_modes_mapping_set = {}
     _ordered_named_fan_speeds = []  # Ordered list of speed names (e.g., ['Low', 'Medium', 'High'])
     _speed_mapping = {}  # Maps modeValue to speed name
     _speed_name_to_mode_value = {}  # Maps speed name to modeValue
@@ -122,6 +119,11 @@ class GoveeLifeFan(FanEntity, GoveeLifePlatformEntity):
         # Get device SKU for model-specific handling
         self._device_sku = self._device_cfg.get("sku", None)
         _LOGGER.debug("%s - %s: Device SKU: %s", self._api_id, self._identifier, self._device_sku)
+
+        # Set per device so duplication of modes does not occur after each HA restart
+        self._attr_preset_modes = []
+        self._attr_preset_modes_mapping = {}
+        self._attr_preset_modes_mapping_set = {}
 
         for cap in capabilities:
             if cap["type"] == "devices.capabilities.on_off":


### PR DESCRIPTION
I noticed that every time I restarted my HA server the fan modes of Govee Air Purifiers were being duplicated. After a few restarts this lead to fan mode lists that looked like this:
<img width="230" height="733" alt="Fan Mode Duplication Image" src="https://github.com/user-attachments/assets/5d5a3c47-6dd9-4684-9c51-3fde466f5eec" />

I've moved the fan modes array / dictionary into the `_init_platform_specific` method, and retargeted the variables to be instance variables instead of class variables. I've tested this locally after changing the source directly and it worked as expected after each restart, fan modes were no longer being duplicated. 

As far as I understand, this was caused by the fan modes array / dictionaries being at the class level, and so I think if you had more than one air purifier (I have 3), then it would basically keep appending to the same data instead of creating a new modes array / dictionary for each device.

I've not had a deep dive into this class / repository so please let me know if this change causes any concerns. 

Thank you! 🙂 
