### PR TITLE
Fix infinite recursion in Govee humidifier is_on property

### DIFF
--- a/custom_components/goveelife/humidifier.py
+++ b/custom_components/goveelife/humidifier.py
@@ -167,7 +167,14 @@ class GoveeLifeHumidifier(HumidifierEntity, GoveeLifePlatformEntity):
     @property
     def is_on(self) -> bool:
         """Return true if entity is on."""
-        return self.state == STATE_ON
+        value = GoveeAPI_GetCachedStateValue(
+            self.hass,
+            self._entry_id,
+            self._device_cfg.get("device"),
+            "devices.capabilities.on_off",
+            "powerSwitch",
+        )
+        return self._state_mapping.get(value) == STATE_ON
 
     @property
     def mode(self) -> str | None:


### PR DESCRIPTION
Fixes a critical bug in the Govee Life humidifier integration where the `is_on` property caused infinite recursion by referencing `self.state`:

```
2026-03-25 14:30:18.648 INFO (MainThread) [custom_components.goveelife.humidifier] 01KMJHS1RNRW47GSFV32C8KZVN - async_setup_entry: setup 1 humidifier entities
2026-03-25 14:30:18.648 INFO (MainThread) [homeassistant.helpers.entity_registry] Registered new humidifier.goveelife entity: humidifier.smart_humidifier_lite
2026-03-25 14:30:18.649 ERROR (MainThread) [homeassistant.components.humidifier] Error adding entity humidifier.smart_humidifier_lite for domain humidifier with platform goveelife
Traceback (most recent call last):
  File "/Users/jan/Public/home-assistant/core/homeassistant/helpers/entity_platform.py", line 680, in _async_add_entities
    await self._async_add_entity(
        entity, False, entity_registry, config_subentry_id
    )
  File "/Users/jan/Public/home-assistant/core/homeassistant/helpers/entity_platform.py", line 998, in _async_add_entity
    await entity.add_to_platform_finish()
  File "/Users/jan/Public/home-assistant/core/homeassistant/helpers/entity.py", line 1431, in add_to_platform_finish
    self.async_write_ha_state()
    ~~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "/Users/jan/Public/home-assistant/core/homeassistant/helpers/entity.py", line 1050, in async_write_ha_state
    self._async_write_ha_state()
    ~~~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "/Users/jan/Public/home-assistant/core/homeassistant/helpers/entity.py", line 1199, in _async_write_ha_state
    ) = self.__async_calculate_state()
        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "/Users/jan/Public/home-assistant/core/homeassistant/helpers/entity.py", line 1106, in __async_calculate_state
    state = self._stringify_state(available)
  File "/Users/jan/Public/home-assistant/core/homeassistant/helpers/entity.py", line 1056, in _stringify_state
    if (state := self.state) is None:
                 ^^^^^^^^^^
  File "/Users/jan/Public/home-assistant/core/homeassistant/helpers/entity.py", line 1727, in state
    if (is_on := self.is_on) is None:
                 ^^^^^^^^^^
  File "/Users/jan/Public/home-assistant/core/config/custom_components/goveelife/humidifier.py", line 170, in is_on
    return self.state == STATE_ON
           ^^^^^^^^^^
  File "/Users/jan/Public/home-assistant/core/homeassistant/helpers/entity.py", line 1727, in state
    if (is_on := self.is_on) is None:
                 ^^^^^^^^^^
  File "/Users/jan/Public/home-assistant/core/config/custom_components/goveelife/humidifier.py", line 170, in is_on
    return self.state == STATE_ON
           ^^^^^^^^^^
  […]
```
