### PR TITLE
Fix FanSpeed mode value mapping for fans

### DIFF
--- a/custom_components/goveelife/fan.py
+++ b/custom_components/goveelife/fan.py
@@ -91,6 +91,7 @@ class GoveeLifeFan(FanEntity, GoveeLifePlatformEntity):
         self._speed_mapping = {}
         self._speed_name_to_mode_value = {}
         self._manual_work_mode = 1
+        self._manual_preset_name = "Manual"
         self._sleep_work_mode = None
         self._flat_work_mode = False
         self._attr_supported_features = 0
@@ -124,6 +125,7 @@ class GoveeLifeFan(FanEntity, GoveeLifePlatformEntity):
                             work_mode_options.append({"name": workOption["name"], "value": workOption["value"]})
                             if workOption["name"].lower() in ["manual", "gearmode", "fanspeed"]:
                                 manual_work_mode = workOption["value"]
+                                self._manual_preset_name = workOption["name"]
                     elif capFieldWork["fieldName"] == "modeValue":
                         # Build reverse lookup for workMode value -> name
                         work_mode_value_to_name = {opt["value"]: opt["name"] for opt in work_mode_options}
@@ -135,6 +137,12 @@ class GoveeLifeFan(FanEntity, GoveeLifePlatformEntity):
                                     gear_name = gearOption.get("name") or f"Speed {gearOption['value']}"
                                     gear_modes.append({"name": gear_name, "value": gearOption["value"]})
                             elif valueOption.get("options"):
+                                if valueOption["name"].lower() in ["manual", "gearmode", "fanspeed"]:
+                                    for subOpt in valueOption["options"]:
+                                        sub_name = subOpt.get("name") or f"Speed {subOpt['value']}"
+                                        gear_modes.append({"name": sub_name, "value": subOpt["value"]})
+                                    continue
+
                                 # Check if this modeValue option corresponds to the manual work mode
                                 value_option_name_to_check = work_mode_value_to_name.get(valueOption.get("value", 0))
                                 if value_option_name_to_check and manual_work_mode is not None:
@@ -241,9 +249,9 @@ class GoveeLifeFan(FanEntity, GoveeLifePlatformEntity):
                                 if manual_work_mode is not None:
                                     if has_power_control:
                                         self._attr_preset_modes.append("Off")
-                                    self._attr_preset_modes.append("Manual")
+                                    self._attr_preset_modes.append(self._manual_preset_name)
                                     if gear_modes:
-                                        self._attr_preset_modes_mapping_set["Manual"] = {
+                                        self._attr_preset_modes_mapping_set[self._manual_preset_name] = {
                                             "workMode": manual_work_mode,
                                             "modeValue": gear_modes[-1]["value"],
                                         }
@@ -254,7 +262,7 @@ class GoveeLifeFan(FanEntity, GoveeLifePlatformEntity):
                                             gear_modes[-1]["name"],
                                             gear_modes[-1]["value"],
                                         )
-                            elif valueOption["name"] != "Custom" and valueOption["name"] != "gearMode":
+                            elif valueOption["name"] != "gearMode":
                                 # Check if this modeValue option name corresponds to the manual work mode name
                                 value_option_is_manual_mode = (
                                     work_mode_value_to_name.get(valueOption.get("value", 0)) == work_mode_value_to_name.get(manual_work_mode)
@@ -268,9 +276,9 @@ class GoveeLifeFan(FanEntity, GoveeLifePlatformEntity):
                                     if manual_work_mode is not None:
                                         if has_power_control:
                                             self._attr_preset_modes.append("Off")
-                                        self._attr_preset_modes.append("Manual")
+                                        self._attr_preset_modes.append(self._manual_preset_name)
                                         if gear_modes:
-                                            self._attr_preset_modes_mapping_set["Manual"] = {
+                                            self._attr_preset_modes_mapping_set[self._manual_preset_name] = {
                                                 "workMode": manual_work_mode,
                                                 "modeValue": gear_modes[-1]["value"],
                                             }
@@ -281,14 +289,17 @@ class GoveeLifeFan(FanEntity, GoveeLifePlatformEntity):
                                                 gear_modes[-1]["name"],
                                                 gear_modes[-1]["value"],
                                             )
-                                elif valueOption["name"] != "Custom":
-                                    # Other modes like Sleep, Auto, etc.
+                                else:
+                                    # Other modes like Sleep, Auto, Custom, etc.
                                     work_mode_value = self._attr_preset_modes_mapping.get(valueOption["name"])
                                     if work_mode_value is not None:
+                                        mode_value = valueOption.get("defaultValue", valueOption.get("value", 0))
+                                        if mode_value == 0 and valueOption.get("options"):
+                                            mode_value = valueOption["options"][0].get("value", 0)
                                         self._attr_preset_modes.append(valueOption["name"])
                                         self._attr_preset_modes_mapping_set[valueOption["name"]] = {
                                             "workMode": work_mode_value,
-                                            "modeValue": valueOption.get("value", 0),
+                                            "modeValue": mode_value,
                                         }
                                         if valueOption["name"].lower() == "sleep":
                                             self._sleep_work_mode = work_mode_value
@@ -320,7 +331,15 @@ class GoveeLifeFan(FanEntity, GoveeLifePlatformEntity):
                         self._identifier,
                         self._ordered_named_fan_speeds,
                     )
+                    self._attr_percentage_step = 100 / len(self._ordered_named_fan_speeds)
                     _LOGGER.debug("%s - %s: Speed mapping: %s", self._api_id, self._identifier, self._speed_mapping)
+
+    @property
+    def speed_count(self) -> int | None:
+        """Return the number of discrete fan speeds."""
+        if self._ordered_named_fan_speeds:
+            return len(self._ordered_named_fan_speeds)
+        return None
 
     @property
     def state(self) -> str | None:
@@ -424,7 +443,7 @@ class GoveeLifeFan(FanEntity, GoveeLifePlatformEntity):
 
         # Standard nested structure
         if work_mode == self._manual_work_mode:
-            return "Manual"
+            return self._manual_preset_name
 
         v = {"workMode": work_mode, "modeValue": mode_value}
         return next(

--- a/tests/fixtures/device_responses/h7106_2026-06-30.json
+++ b/tests/fixtures/device_responses/h7106_2026-06-30.json
@@ -1,0 +1,181 @@
+{
+  "github_issue_url": "https://github.com/disforw/goveelife/issues/70",
+  "sku": "H7106",
+  "device": "AA:BB:CC:DD:EE:FF:00:26",
+  "deviceName": "Smart Tower Fan",
+  "type": "devices.types.fan",
+  "capabilities": [
+    {
+      "type": "devices.capabilities.on_off",
+      "instance": "powerSwitch",
+      "parameters": {
+        "dataType": "ENUM",
+        "options": [
+          {
+            "name": "on",
+            "value": 1
+          },
+          {
+            "name": "off",
+            "value": 0
+          }
+        ]
+      }
+    },
+    {
+      "type": "devices.capabilities.toggle",
+      "instance": "oscillationToggle",
+      "parameters": {
+        "dataType": "ENUM",
+        "options": [
+          {
+            "name": "on",
+            "value": 1
+          },
+          {
+            "name": "off",
+            "value": 0
+          }
+        ]
+      }
+    },
+    {
+      "type": "devices.capabilities.work_mode",
+      "instance": "workMode",
+      "parameters": {
+        "dataType": "STRUCT",
+        "fields": [
+          {
+            "fieldName": "workMode",
+            "dataType": "ENUM",
+            "options": [
+              {
+                "name": "FanSpeed",
+                "value": 1
+              },
+              {
+                "name": "Auto",
+                "value": 2
+              },
+              {
+                "name": "Sleep",
+                "value": 3
+              },
+              {
+                "name": "Nature",
+                "value": 4
+              },
+              {
+                "name": "Custom",
+                "value": 5
+              }
+            ],
+            "required": true
+          },
+          {
+            "fieldName": "modeValue",
+            "dataType": "ENUM",
+            "options": [
+              {
+                "name": "FanSpeed",
+                "options": [
+                  {
+                    "value": 1
+                  },
+                  {
+                    "value": 2
+                  },
+                  {
+                    "value": 3
+                  },
+                  {
+                    "value": 4
+                  },
+                  {
+                    "value": 5
+                  },
+                  {
+                    "value": 6
+                  },
+                  {
+                    "value": 7
+                  },
+                  {
+                    "value": 8
+                  }
+                ]
+              },
+              {
+                "defaultValue": 0,
+                "name": "Auto"
+              },
+              {
+                "name": "Sleep",
+                "options": [
+                  {
+                    "value": 1
+                  },
+                  {
+                    "value": 2
+                  },
+                  {
+                    "value": 3
+                  },
+                  {
+                    "value": 4
+                  },
+                  {
+                    "value": 5
+                  },
+                  {
+                    "value": 6
+                  },
+                  {
+                    "value": 7
+                  },
+                  {
+                    "value": 8
+                  }
+                ]
+              },
+              {
+                "name": "Nature",
+                "options": [
+                  {
+                    "value": 1
+                  },
+                  {
+                    "value": 2
+                  },
+                  {
+                    "value": 3
+                  },
+                  {
+                    "value": 4
+                  },
+                  {
+                    "value": 5
+                  },
+                  {
+                    "value": 6
+                  },
+                  {
+                    "value": 7
+                  },
+                  {
+                    "value": 8
+                  }
+                ]
+              },
+              {
+                "defaultValue": 0,
+                "name": "Custom"
+              }
+            ],
+            "required": true
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/tests/test_fan.py
+++ b/tests/test_fan.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from homeassistant.components.fan import FanEntityFeature
+from homeassistant.const import CONF_API_KEY, CONF_DEVICES, CONF_PARAMS, CONF_SCAN_INTERVAL, CONF_TIMEOUT
+
+from custom_components.goveelife.const import CONF_COORDINATORS, DOMAIN
+from custom_components.goveelife.fan import GoveeLifeFan
+
+DEVICE_RESPONSES_DIR = Path(__file__).parent / "fixtures" / "device_responses"
+
+
+def _load_device_fixture(fixture_file):
+    return json.loads((DEVICE_RESPONSES_DIR / fixture_file).read_text())
+
+
+def _create_fan(device_cfg):
+    hass = MagicMock()
+    entry = MagicMock()
+    entry.entry_id = "test_entry_id"
+    coordinator = MagicMock()
+    coordinator.async_request_refresh = AsyncMock()
+    hass.data = {
+        DOMAIN: {
+            entry.entry_id: {
+                CONF_DEVICES: [device_cfg],
+                CONF_COORDINATORS: {device_cfg["device"]: coordinator},
+                CONF_PARAMS: {
+                    CONF_API_KEY: "fake-api-key",
+                    CONF_SCAN_INTERVAL: 60,
+                    CONF_TIMEOUT: 10,
+                },
+            }
+        }
+    }
+    return GoveeLifeFan(hass, entry, coordinator, device_cfg, platform="fan")
+
+
+@pytest.mark.parametrize(
+    ("fixture_file", "speed_count"),
+    [
+        ("h7106_2026-06-30.json", 8),
+        ("h7107_2025-08-28.json", 12),
+    ],
+)
+def test_fanspeed_mode_values_are_used_as_discrete_speeds(fixture_file, speed_count):
+    device_cfg = _load_device_fixture(fixture_file)
+
+    fan = _create_fan(device_cfg)
+
+    assert fan.supported_features & FanEntityFeature.SET_SPEED
+    assert fan.speed_count == speed_count
+    assert fan.percentage_step == pytest.approx(100 / speed_count)
+    assert fan.preset_modes == ["Off", "FanSpeed", "Auto", "Sleep", "Nature", "Custom"]
+    assert fan._ordered_named_fan_speeds == [f"Speed {speed}" for speed in range(1, speed_count + 1)]
+    assert fan._attr_preset_modes_mapping_set["FanSpeed"] == {"workMode": 1, "modeValue": speed_count}


### PR DESCRIPTION
Fixes fan speed handling for devices like H7106/H7107 where `FanSpeed` is the manual speed mode and `modeValue` contains the actual discrete speed levels.

Previously, the percentage slider could treat `workMode` options as speed levels, causing percentage positions to select modes like Auto, Sleep, Nature, and Custom.

This change:
- builds discrete fan speeds from `FanSpeed` `modeValue` options
- preserves Auto, Sleep, Nature, and Custom as preset modes
- exposes `speed_count` and `percentage_step` based on discovered speeds
- adds an H7106 fixture
- adds tests for H7106 and H7107

Local verification:
- `.\.venv\Scripts\python.exe -m py_compile custom_components\goveelife\fan.py tests\test_fan.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest tests\test_fan.py -q --noconftest` -> 2 passed